### PR TITLE
Correction for the WGS84 transformation parameters

### DIFF
--- a/QGIS_2039_Fix.py
+++ b/QGIS_2039_Fix.py
@@ -51,7 +51,7 @@ db_standalone_path = "C:\\Program Files\\QGIS "+ '.'.join(qgis.utils.Qgis.QGIS_V
 
 
 srid_val = 2039 #Change if needed
-parameters_val = "+proj=tmerc +lat_0=31.7343936111111 +lon_0=35.2045169444445 +k=1.0000067 +x_0=219529.584 +y_0=626907.39 +ellps=GRS80 +towgs84=-24.0024,-17.1032,-17.8444,-0.33009,-1.85269,1.66969,5.4248 +units=m +no_defs"
+parameters_val = "+proj=tmerc +lat_0=31.7343936111111 +lon_0=35.2045169444445 +k=1.0000067 +x_0=219529.584 +y_0=626907.39 +ellps=GRS80 +towgs84=-24.0024,-17.1032,-17.8444,-0.33077,-1.85269,1.66969,5.4248 +units=m +no_defs"
 
 if os.path.isfile(db_network_path):
 	db_path = db_network_path


### PR DESCRIPTION
According to the latest official definition:

[![image](https://user-images.githubusercontent.com/1304610/56420491-d3433100-62a6-11e9-82e5-ea44a961fd24.png)](https://he.wikisource.org/wiki/%D7%AA%D7%A7%D7%A0%D7%95%D7%AA_%D7%94%D7%9E%D7%93%D7%99%D7%93%D7%95%D7%AA_(%D7%9E%D7%93%D7%99%D7%93%D7%95%D7%AA_%D7%95%D7%9E%D7%99%D7%A4%D7%95%D7%99)#%D7%AA%D7%95%D7%A1%D7%A4%D7%AA_1)

Notes:

- As far as I understand, this is the legally-binding definition.
- See also in page 36 of the [mapi.gov.il official publication](http://mapi.gov.il/ProfessionalInfo/chanit/takanot/2016-survey-regulations-records.pdf)